### PR TITLE
Make Filesystem directives more consistent

### DIFF
--- a/dotfiles_actions/src/lib.rs
+++ b/dotfiles_actions/src/lib.rs
@@ -38,6 +38,7 @@
 pub mod brew;
 pub mod create;
 pub mod exec;
+pub mod filesystem;
 #[cfg(unix)]
 pub mod homebrew_install;
 #[cfg(unix)]

--- a/dotfiles_actions/tests/create/directive.rs
+++ b/dotfiles_actions/tests/create/directive.rs
@@ -22,19 +22,19 @@
 #![cfg(test)]
 use crate::utils::{read_test_yaml, setup_fs};
 
-use dotfiles_actions::create::directive::CreateDirective;
+use dotfiles_actions::create::directive::FakeCreateDirective;
+use dotfiles_actions::filesystem::FileSystemDirective;
 use dotfiles_core::action::ActionParser;
 use dotfiles_core::error::DotfilesError;
 use dotfiles_core::settings::Settings;
 use dotfiles_core::Action;
-
 use filesystem::FakeFileSystem;
 
 #[test]
 fn create_directive_parsed_from_single_dir_name() -> Result<(), DotfilesError> {
   let fs = FakeFileSystem::new();
   setup_fs(&fs)?;
-  let directive = CreateDirective::new(fs);
+  let directive = FakeCreateDirective::new(fs);
   let default_settings = Settings::new();
   let yaml = read_test_yaml("directive/create/plain_directory_name.yaml")
     .unwrap()
@@ -52,7 +52,7 @@ fn create_directive_parsed_from_single_dir_name() -> Result<(), DotfilesError> {
 fn create_directive_parsed_from_full_action() -> Result<(), DotfilesError> {
   let fs = FakeFileSystem::new();
   setup_fs(&fs)?;
-  let directive = CreateDirective::new(fs);
+  let directive = FakeCreateDirective::new(fs);
   let default_settings = Settings::new();
   let yaml = read_test_yaml("directive/create/full_action.yaml")
     .unwrap()

--- a/dotfiles_actions/tests/link/directive.rs
+++ b/dotfiles_actions/tests/link/directive.rs
@@ -20,15 +20,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #![cfg(test)]
-use crate::utils::read_test_yaml;
-use crate::utils::setup_fs;
+use crate::utils::{read_test_yaml, setup_fs};
 
-use dotfiles_actions::link::directive::LinkDirective;
+use dotfiles_actions::filesystem::FileSystemDirective;
+use dotfiles_actions::link::directive::FakeLinkDirective;
+
 use dotfiles_core::error::DotfilesError;
 use dotfiles_core::settings::Settings;
 use dotfiles_core::Action;
-use filesystem::FakeFileSystem;
-use filesystem::FileSystem;
+
+use filesystem::{FakeFileSystem, FileSystem};
 
 #[test]
 fn link_directive_parsed_from_plain_link() -> Result<(), DotfilesError> {
@@ -36,7 +37,7 @@ fn link_directive_parsed_from_plain_link() -> Result<(), DotfilesError> {
   setup_fs(&fs)?;
   fs.create_file("/home/user/the_file", String::from("aaa").as_bytes())
     .unwrap();
-  let directive = LinkDirective::new(fs);
+  let directive = FakeLinkDirective::new(fs);
   let default_settings = Settings::new();
   let yaml = read_test_yaml("directive/link/plain_link.yaml")
     .unwrap()

--- a/dotfiles_processor/src/process.rs
+++ b/dotfiles_processor/src/process.rs
@@ -19,10 +19,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use dotfiles_actions::brew::directive::BrewDirective;
-use dotfiles_actions::create::directive::new_native_create_directive;
 use dotfiles_actions::exec::directive::ExecDirective;
-use dotfiles_actions::link::directive::new_native_link_directive;
+use dotfiles_actions::link::directive::NativeLinkDirective;
+use dotfiles_actions::{brew::directive::BrewDirective, create::directive::NativeCreateDirective};
 use dotfiles_core::directive::DirectiveSet;
 use dotfiles_core::Action;
 
@@ -57,8 +56,8 @@ pub fn initialize_directive_set<'a>(
   directive_set: &'a mut DirectiveSet,
 ) -> Result<(), DotfilesError> {
   directive_set.add("brew", Box::new(BrewDirective::default()))?;
-  directive_set.add("create", Box::new(new_native_create_directive()))?;
+  directive_set.add("create", Box::new(NativeCreateDirective::default()))?;
   directive_set.add("exec", Box::new(ExecDirective::default()))?;
-  directive_set.add("link", Box::new(new_native_link_directive()))?;
+  directive_set.add("link", Box::new(NativeLinkDirective::default()))?;
   Ok(())
 }


### PR DESCRIPTION
Summary:

- Creates a new FileSystemDirective trait that defines common behavior, including creating a new instance out a given filesystem instance.
- Makes it possible to use default for Both Link and Create directives.
- Cleans up and clippies code

Test Plan:

Documentation Plan:

Revert Plan: